### PR TITLE
fix(security): HTML-escape user input in ProductController.directLink

### DIFF
--- a/src/main/java/org/workshop/coffee/controller/ProductController.java
+++ b/src/main/java/org/workshop/coffee/controller/ProductController.java
@@ -98,7 +98,7 @@ public class ProductController {
 
         writer.write(head);
 
-        writer.write("<div class=\"panel-heading\"><h1>" + productName + "</h1></div>");
+        writer.write("<div class=\"panel-heading\"><h1>" + HtmlUtils.htmlEscape(productName) + "</h1></div>");
 
         String output = "<div class=\"panel-body\">" +
                 "<ul>" +
@@ -108,7 +108,10 @@ public class ProductController {
                 "</ul>" +
                 "</div>";
 
-        writer.write(String.format(output, desc, productType, price));
+        writer.write(String.format(output,
+                HtmlUtils.htmlEscape(desc == null ? "" : desc),
+                HtmlUtils.htmlEscape(productType == null ? "" : productType.toString()),
+                HtmlUtils.htmlEscape(String.valueOf(price))));
         writer.write(foot);
 
 


### PR DESCRIPTION
## Summary

Fixes two HIGH-severity Snyk Code findings in `ProductController.directLink` (`GET /products/direct?param=...`) where user-controlled input was written into the HTTP response body without escaping.

| Severity | Finding ID | File:Line | Issue |
|---|---|---|---|
| HIGH | `ea765108-815e-4970-a7c1-672941a950ba` | `ProductController.java:101` | `productName` (query param) rendered into HTML unescaped |
| HIGH | `4869d263-8f66-45d2-8071-2f1d74ac90b8` | `ProductController.java:111` | `desc`, `productType`, `price` interpolated into HTML unescaped |

## Fix

Apply `org.springframework.web.util.HtmlUtils.htmlEscape(...)` to all user-controlled values before writing to the response. `HtmlUtils` was already imported but unused — no new dependencies.

Added null-safety because `productService.getProductByName(param)` returns `null` for unknown names, in which case a `new Product()` with null fields is rendered (see lines 73-75).

## Test Plan

- [ ] Re-run `snyk code test` — both XSS findings should no longer appear
- [ ] Manual: `GET /products/direct?param=<script>alert(1)</script>` should render literal text, no JS execution
- [ ] Manual: Add a product with description `<img src=x onerror=alert(1)>`, view via `/products/direct` — should render literal text
- [ ] `./mvnw clean verify` should pass (no API changes; no test changes needed)

## Out of scope

Other Snyk findings (CSRF disabled in `SecurityConfig`, deserialization in `OrderController`, hardcoded password in `PersonController`) will be addressed in follow-up PRs.