### PR TITLE
fix(security): resolve Snyk Code criticals + XSS in ProductController

### DIFF
--- a/src/main/java/org/workshop/coffee/config/SecurityConfig.java
+++ b/src/main/java/org/workshop/coffee/config/SecurityConfig.java
@@ -40,8 +40,8 @@ public class SecurityConfig {
                         logout -> logout.logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
                                 .permitAll()
                 )
-                .csrf().disable().headers().frameOptions().disable()
-                .and().requestCache().disable();
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
+                .requestCache().disable();
 
         return http.build();
     }

--- a/src/main/java/org/workshop/coffee/controller/PersonController.java
+++ b/src/main/java/org/workshop/coffee/controller/PersonController.java
@@ -3,6 +3,7 @@ package org.workshop.coffee.controller;
 import org.workshop.coffee.domain.Person;
 import org.workshop.coffee.service.PersonService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -13,15 +14,21 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.validation.Valid;
+import java.security.SecureRandom;
+import java.util.Base64;
 
 @Controller
 @RequestMapping("/persons")
 public class PersonController {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     private final PersonService personService;
+    private final PasswordEncoder passwordEncoder;
 
     @Autowired
-    public PersonController(PersonService personService) {
+    public PersonController(PersonService personService, PasswordEncoder passwordEncoder) {
         this.personService = personService;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @GetMapping
@@ -52,7 +59,10 @@ public class PersonController {
         boolean isAdd = person.getId() == null;
 
         if (isAdd) {
-            person.setPassword("123123");
+            byte[] tempBytes = new byte[24];
+            SECURE_RANDOM.nextBytes(tempBytes);
+            String tempPassword = Base64.getUrlEncoder().withoutPadding().encodeToString(tempBytes);
+            person.setPassword(passwordEncoder.encode(tempPassword));
         }
 
         personService.savePerson(person);

--- a/src/main/java/org/workshop/coffee/export/YamlImportExport.java
+++ b/src/main/java/org/workshop/coffee/export/YamlImportExport.java
@@ -4,7 +4,9 @@ import org.workshop.coffee.domain.Order;
 import org.workshop.coffee.domain.Person;
 import org.springframework.http.MediaType;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
 
 import java.io.InputStream;
 import java.util.List;
@@ -30,9 +32,25 @@ public class YamlImportExport {
 
 
     public static List<Order> importOrders(InputStream inputStream, Person person) {
-        Yaml yaml = new Yaml();
-        List<ExportOrder> orders = yaml.load(inputStream);
-        return orders.stream()
+        // Safe deserialization: restrict to known types only to prevent
+        // SnakeYAML gadget-chain RCE via arbitrary class instantiation.
+        Constructor constructor = new Constructor(ExportOrder.class);
+        TypeDescription exportOrderDesc = new TypeDescription(ExportOrder.class);
+        exportOrderDesc.addPropertyParameters("orderLines", ExportOrderLine.class);
+        constructor.addTypeDescription(exportOrderDesc);
+
+        Yaml yaml = new Yaml(constructor);
+        Iterable<Object> documents = yaml.loadAll(inputStream);
+
+        return java.util.stream.StreamSupport.stream(documents.spliterator(), false)
+                .flatMap(doc -> {
+                    if (doc instanceof List) {
+                        return ((List<?>) doc).stream();
+                    }
+                    return java.util.stream.Stream.of(doc);
+                })
+                .filter(ExportOrder.class::isInstance)
+                .map(ExportOrder.class::cast)
                 .map(eo -> ExportOrderConvertor.createOrders(eo, person))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## Summary

Resolves all open Snyk Code findings on this branch (4 total across 2 commits).

### Commit beaa6e5 — XSS fix
- `ProductController.directLink`: HTML-escape user input before rendering.

### Commit 641b805 — Snyk criticals
- **CSRF (HIGH)** — `SecurityConfig`: removed `.csrf().disable()`. Spring Security now enforces CSRF tokens on all state-changing endpoints. `frameOptions` scoped to `sameOrigin` instead of fully disabled.
- **Unsafe Deserialization (HIGH)** — `YamlImportExport.importOrders`: replaced bare `new Yaml().load(...)` with a typed `Constructor(ExportOrder.class)` + explicit `TypeDescription` for `orderLines`. Prevents SnakeYAML gadget-chain RCE from attacker-controlled YAML uploads.
- **Hardcoded Password (MEDIUM)** — `PersonController.savePerson`: replaced default `"123123"` with a 24-byte `SecureRandom` value encoded via the injected `PasswordEncoder`.

## Test Plan

- [x] `snyk code test` — 3 open issues → **0 open issues**
- [ ] Verify H2 console behavior in dev (CSRF is now enforced globally; H2 console should be moved to a dev-only profile in a follow-up)
- [ ] Verify person-create flow (admin will need a "send reset link" follow-up since the temp password is no longer human-visible)
- [ ] Verify YAML import still parses valid `ExportOrder` payloads end-to-end

## Follow-ups (not in this PR)

- Move H2 console to `@Profile("dev")` so CSRF can stay enabled in prod without exceptions.
- Add a password-reset / first-login-change flow for newly created persons.